### PR TITLE
Name fields in flag struct literals

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,6 +1,6 @@
 {
-	"ImportPath": "github.com/meatballhat/artifacts",
-	"GoVersion": "go1.2.2",
+	"ImportPath": "github.com/travis-ci/artifacts",
+	"GoVersion": "go1.3",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -14,6 +14,36 @@
 		{
 			"ImportPath": "github.com/dustin/go-humanize",
 			"Rev": "3cd90eb3d932037b141d4daff9a012e1aee7e765"
+		},
+		{
+			"ImportPath": "github.com/meatballhat/artifacts/artifact",
+			"Comment": "v0.6.2-4-g5d61fbf",
+			"Rev": "5d61fbfaaa39b6b75f1a1d9bcec6b2e8b0ba99ab"
+		},
+		{
+			"ImportPath": "github.com/meatballhat/artifacts/client",
+			"Comment": "v0.6.2-4-g5d61fbf",
+			"Rev": "5d61fbfaaa39b6b75f1a1d9bcec6b2e8b0ba99ab"
+		},
+		{
+			"ImportPath": "github.com/meatballhat/artifacts/env",
+			"Comment": "v0.6.2-4-g5d61fbf",
+			"Rev": "5d61fbfaaa39b6b75f1a1d9bcec6b2e8b0ba99ab"
+		},
+		{
+			"ImportPath": "github.com/meatballhat/artifacts/logging",
+			"Comment": "v0.6.2-4-g5d61fbf",
+			"Rev": "5d61fbfaaa39b6b75f1a1d9bcec6b2e8b0ba99ab"
+		},
+		{
+			"ImportPath": "github.com/meatballhat/artifacts/path",
+			"Comment": "v0.6.2-4-g5d61fbf",
+			"Rev": "5d61fbfaaa39b6b75f1a1d9bcec6b2e8b0ba99ab"
+		},
+		{
+			"ImportPath": "github.com/meatballhat/artifacts/upload",
+			"Comment": "v0.6.2-4-g5d61fbf",
+			"Rev": "5d61fbfaaa39b6b75f1a1d9bcec6b2e8b0ba99ab"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/goamz/aws",

--- a/artifacts.go
+++ b/artifacts.go
@@ -38,22 +38,77 @@ function "DetectContentType".
 
 var (
 	uploadFlags = []cli.Flag{
-		cli.StringFlag{"key, k", "", "upload credentials key ($ARTIFACTS_KEY) *REQUIRED*"},
-		cli.StringFlag{"bucket, b", "", "destination bucket ($ARTIFACTS_BUCKET) *REQUIRED*"},
-		cli.StringFlag{"cache-control", "", fmt.Sprintf("artifact cache-control header value ($ARTIFACTS_CACHE_CONTROL) (default %q)", upload.DefaultCacheControl)},
-		cli.StringFlag{"permissions", "", fmt.Sprintf("artifact access permissions ($ARTIFACTS_PERMISSIONS) (default %q)", upload.DefaultPerm)},
-		cli.StringFlag{"secret, s", "", "upload credentials secret ($ARTIFACTS_SECRET) *REQUIRED*"},
-
-		cli.StringFlag{"concurrency", "", fmt.Sprintf("upload worker concurrency ($ARTIFACTS_CONCURRENCY) (default %v)", upload.DefaultConcurrency)},
-		cli.StringFlag{"max-size", "", fmt.Sprintf("max combined size of uploaded artifacts ($ARTIFACTS_MAX_SIZE) (default %v)", humanize.Bytes(upload.DefaultMaxSize))},
-		cli.StringFlag{"retries", "", fmt.Sprintf("number of upload retries per artifact ($ARTIFACT_RETRIES) (default %v)", upload.DefaultRetries)},
-		cli.StringFlag{"target-paths, t", "", fmt.Sprintf("artifact target paths (':'-delimited) ($ARTIFACTS_TARGET_PATHS) (default %#v)", upload.DefaultTargetPaths)},
-		cli.StringFlag{"working-dir", "", "working directory ($TRAVIS_BUILD_DIR) (default $PWD)"},
-
-		cli.StringFlag{"upload-provider, p", "", fmt.Sprintf("artifact upload provider (artifacts, s3, null) ($ARTIFACTS_UPLOAD_PROVIDER) (default %#v)", upload.DefaultUploadProvider)},
-
-		cli.StringFlag{"save-host, H", "", "artifact save host ($ARTIFACTS_SAVE_HOST)"},
-		cli.StringFlag{"auth-token, T", "", "artifact save auth token ($ARTIFACTS_AUTH_TOKEN)"},
+		cli.StringFlag{
+			Name:  "key, k",
+			Value: "",
+			Usage: "upload credentials key ($ARTIFACTS_KEY) *REQUIRED*",
+		},
+		cli.StringFlag{
+			Name:  "bucket, b",
+			Value: "",
+			Usage: "destination bucket ($ARTIFACTS_BUCKET) *REQUIRED*",
+		},
+		cli.StringFlag{
+			Name: "cache-control", Value: "",
+			Usage: fmt.Sprintf("artifact cache-control header value ($ARTIFACTS_CACHE_CONTROL) (default %q)",
+				upload.DefaultCacheControl),
+		},
+		cli.StringFlag{
+			Name:  "permissions",
+			Value: "",
+			Usage: fmt.Sprintf("artifact access permissions ($ARTIFACTS_PERMISSIONS) (default %q)",
+				upload.DefaultPerm),
+		},
+		cli.StringFlag{
+			Name:  "secret, s",
+			Value: "",
+			Usage: "upload credentials secret ($ARTIFACTS_SECRET) *REQUIRED*",
+		},
+		cli.StringFlag{
+			Name:  "concurrency",
+			Value: "",
+			Usage: fmt.Sprintf("upload worker concurrency ($ARTIFACTS_CONCURRENCY) (default %v)",
+				upload.DefaultConcurrency),
+		},
+		cli.StringFlag{
+			Name:  "max-size",
+			Value: "",
+			Usage: fmt.Sprintf("max combined size of uploaded artifacts ($ARTIFACTS_MAX_SIZE) (default %v)",
+				humanize.Bytes(upload.DefaultMaxSize)),
+		},
+		cli.StringFlag{
+			Name:  "retries",
+			Value: "",
+			Usage: fmt.Sprintf("number of upload retries per artifact ($ARTIFACT_RETRIES) (default %v)",
+				upload.DefaultRetries),
+		},
+		cli.StringFlag{
+			Name:  "target-paths, t",
+			Value: "",
+			Usage: fmt.Sprintf("artifact target paths (':'-delimited) ($ARTIFACTS_TARGET_PATHS) (default %#v)",
+				upload.DefaultTargetPaths),
+		},
+		cli.StringFlag{
+			Name:  "working-dir",
+			Value: "",
+			Usage: "working directory ($TRAVIS_BUILD_DIR) (default $PWD)",
+		},
+		cli.StringFlag{
+			Name:  "upload-provider, p",
+			Value: "",
+			Usage: fmt.Sprintf("artifact upload provider (artifacts, s3, null) ($ARTIFACTS_UPLOAD_PROVIDER) (default %#v)",
+				upload.DefaultUploadProvider),
+		},
+		cli.StringFlag{
+			Name:  "save-host, H",
+			Value: "",
+			Usage: "artifact save host ($ARTIFACTS_SAVE_HOST)",
+		},
+		cli.StringFlag{
+			Name:  "auth-token, T",
+			Value: "",
+			Usage: "artifact save auth token ($ARTIFACTS_AUTH_TOKEN)",
+		},
 	}
 )
 
@@ -68,8 +123,8 @@ func buildApp() *cli.App {
 	app.Usage = "manage your artifacts!"
 	app.Version = VersionString
 	app.Flags = []cli.Flag{
-		cli.StringFlag{"log-format, f", "", "log output format (text, json, or multiline)"},
-		cli.BoolFlag{"debug, D", "set log level to debug"},
+		cli.StringFlag{Name: "log-format, f", Value: "", Usage: "log output format (text, json, or multiline)"},
+		cli.BoolFlag{Name: "debug, D", Usage: "set log level to debug"},
 	}
 	app.Commands = []cli.Command{
 		{


### PR DESCRIPTION
Newer version of codegansta/cli adds a field to the flag structs which
stops people from being able to `go get` this repository.

Alternative would be to be bundle binaries with the releases (currently it looks like just source code).
