### PR TITLE
Exclude empty '.deps' file from upload

### DIFF
--- a/deploy
+++ b/deploy
@@ -7,7 +7,9 @@ if ! sha256sum --version &>/dev/null ; then
   SHA256SUMMER=gsha256sum
 fi
 
-export ARTIFACTS_PATHS="$(git ls-files -o | tr "\n" ":"):SHA256SUMS"
+export ARTIFACTS_PATHS="$(
+  git ls-files -o | grep -v '\.deps' | tr "\n" ":"
+):SHA256SUMS"
 $SHA256SUMMER ${ARTIFACTS_PATHS//:/ } > SHA256SUMS
 
 echo "    TRAVIS_BRANCH=\"$TRAVIS_BRANCH\""
@@ -16,7 +18,7 @@ echo "    TRAVIS_PULL_REQUEST=\"$TRAVIS_PULL_REQUEST\""
 echo "    TRAVIS_TAG=\"$TRAVIS_TAG\""
 
 if [[ "x$TRAVIS_BRANCH" == "xmaster" ]] &&
-   [[ "x$TRAVIS_GO_VERSION" == "x1.5.1" ]] &&
+   [[ "x$TRAVIS_GO_VERSION" == "x1.10.2" ]] &&
    [[ "x$TRAVIS_PULL_REQUEST" == "xfalse" ]] &&
    [[ "x$TRAVIS_TAG" == "x" ]] ; then
   echo "    # Deploying as 'stable'"


### PR DESCRIPTION
and release when on go 1.10.2