### PR TITLE
Fix the output when uploading artifacts to show the correct download URL

### DIFF
--- a/upload/s3_provider.go
+++ b/upload/s3_provider.go
@@ -111,9 +111,8 @@ func (s3p *s3Provider) rawUpload(opts *Options, b *s3.Bucket, a *artifact.Artifa
 		return err
 	}
 
-	downloadHost := fmt.Sprintf("%s/%s", s3p.getRegion().S3Endpoint, b.Name)
 	s3p.log.WithFields(logrus.Fields{
-		"download_url": fmt.Sprintf("%s/%s", downloadHost, dest),
+		"download_url": fmt.Sprintf("%s/%s/%s", s3p.getRegion().S3Endpoint, b.Name, dest),
 	}).Info(fmt.Sprintf("uploading: %s (size: %s)", a.Source, humanize.Bytes(size)))
 
 	s3p.log.WithFields(logrus.Fields{

--- a/upload/s3_provider.go
+++ b/upload/s3_provider.go
@@ -111,10 +111,7 @@ func (s3p *s3Provider) rawUpload(opts *Options, b *s3.Bucket, a *artifact.Artifa
 		return err
 	}
 
-	downloadHost := s3p.getRegion().S3BucketEndpoint
-	if downloadHost == "" {
-		downloadHost = fmt.Sprintf("https://s3.amazonaws.com/%s", b.Name)
-	}
+	downloadHost := fmt.Sprintf("%s/%s", s3p.getRegion().S3Endpoint, b.Name)
 	s3p.log.WithFields(logrus.Fields{
 		"download_url": fmt.Sprintf("%s/%s", downloadHost, dest),
 	}).Info(fmt.Sprintf("uploading: %s (size: %s)", a.Source, humanize.Bytes(size)))


### PR DESCRIPTION
The default generated URL displayed after successfully uploading an artifact is incorrect. This change fixes the displayed URL, using the S3Endpoint value that is correct for each region.