### PR TITLE
Add ppc64le to the build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOBUILD_LDFLAGS := -ldflags "\
 "
 GOBUILD_FLAGS ?=
 GOTEST_FLAGS ?=
-GOX_OSARCH ?= linux/amd64 darwin/amd64 windows/amd64
+GOX_OSARCH ?= linux/amd64 darwin/amd64 windows/amd64 linux/ppc64le
 GOX_FLAGS ?= -output="build/{{.OS}}/{{.Arch}}/{{.Dir}}" -osarch="$(GOX_OSARCH)"
 
 TRAVIS_BUILD_DIR ?= .


### PR DESCRIPTION
[This](https://travis-ci.org/travis-ci/artifacts/jobs/460721069#L809-L813) looks promising:

```
-->    darwin/amd64: github.com/travis-ci/artifacts
-->   linux/ppc64le: github.com/travis-ci/artifacts
-->   windows/amd64: github.com/travis-ci/artifacts
-->     linux/amd64: github.com/travis-ci/artifacts
The command "make distclean all crossbuild" exited with 0.
```